### PR TITLE
Change the app name to Uttil

### DIFF
--- a/CarGurus App/android/app/src/main/AndroidManifest.xml
+++ b/CarGurus App/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application
-        android:label="CarGurus"
+        android:label="Uttil"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <meta-data

--- a/CarGurus App/ios/Runner/Info.plist
+++ b/CarGurus App/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cargurus</string>
+    <string>Uttil</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/CarGurus App/web/manifest.json
+++ b/CarGurus App/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "cargurus",
-    "short_name": "cargurus",
+    "name": "Uttil",
+    "short_name": "Uttil",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/CarGurus App/windows/CMakeLists.txt
+++ b/CarGurus App/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cargurus LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "cargurus")
+set(BINARY_NAME "Uttil")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.


### PR DESCRIPTION
Se cambie el nombre del proyecto en todos los entornos a Uttil, siguiendo el manual de marca definido